### PR TITLE
Initialize skeleton project per design draft

### DIFF
--- a/data/locations/town_square_state.json
+++ b/data/locations/town_square_state.json
@@ -1,0 +1,8 @@
+{
+  "id": "town_square",
+  "occupants": ["npc_sample"],
+  "items": [],
+  "sublocations": [],
+  "transient_effects": [],
+  "connections_state": {}
+}

--- a/data/locations/town_square_static.json
+++ b/data/locations/town_square_static.json
@@ -1,0 +1,6 @@
+{
+  "id": "town_square",
+  "description": "A simple town square with a fountain in the middle.",
+  "tags": {"inherent": []},
+  "hex_connections": {}
+}

--- a/data/npcs/sample_npc.json
+++ b/data/npcs/sample_npc.json
@@ -1,0 +1,11 @@
+{
+  "id": "npc_sample",
+  "name": "Sample NPC",
+  "inventory": [],
+  "slots": {"main_hand": null, "off_hand": null, "head": null, "torso": null, "legs": null},
+  "hp": 10,
+  "memories": [],
+  "goals": [],
+  "relationships": {},
+  "tags": {"inherent": [], "dynamic": []}
+}

--- a/engine/data_models.py
+++ b/engine/data_models.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class NPC:
+    id: str
+    name: str
+    inventory: List[str] = field(default_factory=list)
+    slots: Dict[str, Optional[str]] = field(default_factory=dict)
+    hp: int = 0
+    memories: List[dict] = field(default_factory=list)
+    goals: List[dict] = field(default_factory=list)
+    relationships: Dict[str, str] = field(default_factory=dict)
+    tags: Dict[str, List[str]] = field(default_factory=lambda: {"inherent": [], "dynamic": []})
+    known_locations: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class LocationStatic:
+    id: str
+    description: str
+    tags: Dict[str, List[str]] = field(default_factory=lambda: {"inherent": []})
+    hex_connections: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class LocationState:
+    id: str
+    occupants: List[str] = field(default_factory=list)
+    items: List[str] = field(default_factory=list)
+    sublocations: List[str] = field(default_factory=list)
+    transient_effects: List[str] = field(default_factory=list)
+    connections_state: Dict[str, dict] = field(default_factory=dict)

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+from .data_models import NPC, LocationStatic, LocationState
+
+
+class WorldState:
+    def __init__(self, data_dir: Path):
+        self.data_dir = data_dir
+        self.npcs: Dict[str, NPC] = {}
+        self.locations_static: Dict[str, LocationStatic] = {}
+        self.locations_state: Dict[str, LocationState] = {}
+
+    def load(self):
+        self._load_npcs()
+        self._load_locations()
+
+    def _load_npcs(self):
+        npcs_dir = self.data_dir / "npcs"
+        for path in npcs_dir.glob("*.json"):
+            with open(path, "r") as f:
+                data = json.load(f)
+            npc = NPC(**data)
+            self.npcs[npc.id] = npc
+
+    def _load_locations(self):
+        loc_dir = self.data_dir / "locations"
+        for path in loc_dir.glob("*_static.json"):
+            with open(path, "r") as f:
+                data = json.load(f)
+            loc = LocationStatic(**data)
+            self.locations_static[loc.id] = loc
+        for path in loc_dir.glob("*_state.json"):
+            with open(path, "r") as f:
+                data = json.load(f)
+            loc = LocationState(**data)
+            self.locations_state[loc.id] = loc
+
+    def get_npc(self, npc_id: str) -> NPC:
+        return self.npcs[npc_id]
+
+    def get_location_static(self, loc_id: str) -> LocationStatic:
+        return self.locations_static[loc_id]
+
+    def get_location_state(self, loc_id: str) -> LocationState:
+        return self.locations_state[loc_id]

--- a/scripts/test_loader.py
+++ b/scripts/test_loader.py
@@ -1,0 +1,15 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pathlib import Path
+
+from engine.world_state import WorldState
+
+
+def main():
+    world = WorldState(Path("data"))
+    world.load()
+    sample_npc = world.get_npc("npc_sample")
+    print(f"Loaded NPC: {sample_npc.name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create basic data schemas and world state loader
- add example data files for a sample NPC and location
- provide a test script to verify loading works

## Testing
- `python3 scripts/test_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_688bd846d434832ea83d0c1610b4dfaa