### PR TITLE
Add item support and grabbing tool

### DIFF
--- a/data/items/catalog.json
+++ b/data/items/catalog.json
@@ -1,0 +1,6 @@
+{
+  "rusty_sword": {
+    "name": "Rusty Sword",
+    "weight": 3
+  }
+}

--- a/data/items/instances/item_rusty_sword_1.json
+++ b/data/items/instances/item_rusty_sword_1.json
@@ -1,0 +1,4 @@
+{
+  "id": "item_rusty_sword_1",
+  "blueprint_id": "rusty_sword"
+}

--- a/data/locations/market_square_state.json
+++ b/data/locations/market_square_state.json
@@ -1,7 +1,9 @@
 {
   "id": "market_square",
   "occupants": [],
-  "items": [],
+  "items": [
+    "item_rusty_sword_1"
+  ],
   "sublocations": [],
   "transient_effects": [],
   "connections_state": {}

--- a/engine/data_models.py
+++ b/engine/data_models.py
@@ -33,3 +33,14 @@ class LocationState:
     sublocations: List[str] = field(default_factory=list)
     transient_effects: List[str] = field(default_factory=list)
     connections_state: Dict[str, dict] = field(default_factory=dict)
+
+@dataclass
+class ItemBlueprint:
+    id: str
+    name: str
+    weight: int = 0
+
+@dataclass
+class ItemInstance:
+    id: str
+    blueprint_id: str

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -47,5 +47,10 @@ class Simulator:
             if loc_id:
                 loc = self.world.get_location_static(loc_id)
                 print(loc.description)
+        elif event.event_type == "grab":
+            self.world.apply_event(event)
+            item = self.world.get_item_instance(event.target_ids[0])
+            bp = self.world.get_item_blueprint(item.blueprint_id)
+            print(f"Picked up {bp.name}.")
         else:
             self.world.apply_event(event)

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -1,2 +1,3 @@
 from .move import MoveTool
 from .look import LookTool
+from .grab import GrabTool

--- a/engine/tools/grab.py
+++ b/engine/tools/grab.py
@@ -1,0 +1,31 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class GrabTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="grab", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        item_id = intent.get("item_id")
+        if not item_id or item_id not in world.item_instances:
+            return False
+        loc_id = world.find_npc_location(actor.id)
+        if not loc_id:
+            return False
+        loc_state = world.get_location_state(loc_id)
+        return item_id in loc_state.items
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="grab",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["item_id"]],
+            )
+        ]

--- a/scripts/demo_simulator.py
+++ b/scripts/demo_simulator.py
@@ -5,6 +5,7 @@ from engine.world_state import WorldState
 from engine.simulator import Simulator
 from engine.tools.move import MoveTool
 from engine.tools.look import LookTool
+from engine.tools.grab import GrabTool
 
 
 def main():
@@ -13,6 +14,7 @@ def main():
     sim = Simulator(world)
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
+    sim.register_tool(GrabTool())
 
     print("Initial location occupants:")
     for loc_id, loc in world.locations_state.items():
@@ -23,9 +25,15 @@ def main():
     for _ in range(6):
         sim.tick()
 
+    grab_cmd = {"tool": "grab", "params": {"item_id": "item_rusty_sword_1"}}
+    sim.process_command("npc_sample", grab_cmd)
+    sim.tick()
+
     print("After move:")
     for loc_id, loc in world.locations_state.items():
         print(loc_id, loc.occupants)
+
+    print("Inventory after grab:", world.get_npc("npc_sample").inventory)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce item catalog and instance data
- load items into `WorldState`
- implement a `GrabTool` and register it
- handle `grab` events in the simulator
- demo script uses move and grab

## Testing
- `python3 scripts/demo_simulator.py`
- `python3 scripts/test_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688be73ae324832e95cc38cc0421c0a8