### PR TITLE
Add basic attack tool and enemy NPC

### DIFF
--- a/data/locations/town_square_state.json
+++ b/data/locations/town_square_state.json
@@ -1,6 +1,6 @@
 {
   "id": "town_square",
-  "occupants": ["npc_sample"],
+  "occupants": ["npc_sample", "npc_enemy"],
   "items": [],
   "sublocations": [],
   "transient_effects": [],

--- a/data/npcs/enemy_npc.json
+++ b/data/npcs/enemy_npc.json
@@ -1,0 +1,21 @@
+{
+  "id": "npc_enemy",
+  "name": "Angry Peasant",
+  "inventory": [],
+  "slots": {
+    "main_hand": null,
+    "off_hand": null,
+    "head": null,
+    "torso": null,
+    "legs": null
+  },
+  "hp": 5,
+  "memories": [],
+  "goals": [],
+  "relationships": {},
+  "tags": {
+    "inherent": [],
+    "dynamic": []
+  },
+  "next_available_tick": 0
+}

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -52,5 +52,11 @@ class Simulator:
             item = self.world.get_item_instance(event.target_ids[0])
             bp = self.world.get_item_blueprint(item.blueprint_id)
             print(f"Picked up {bp.name}.")
+        elif event.event_type == "attack":
+            self.world.apply_event(event)
+            attacker = self.world.get_npc(event.actor_id)
+            target = self.world.get_npc(event.target_ids[0])
+            dmg = event.payload.get("damage", 0)
+            print(f"{attacker.name} hits {target.name} for {dmg} damage (HP: {target.hp})")
         else:
             self.world.apply_event(event)

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -1,3 +1,11 @@
 from .move import MoveTool
 from .look import LookTool
 from .grab import GrabTool
+from .attack import AttackTool
+
+__all__ = [
+    "MoveTool",
+    "LookTool",
+    "GrabTool",
+    "AttackTool",
+]

--- a/engine/tools/attack.py
+++ b/engine/tools/attack.py
@@ -1,0 +1,31 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class AttackTool(Tool):
+    def __init__(self, time_cost: int = 3, damage: int = 1):
+        super().__init__(name="attack", time_cost=time_cost)
+        self.damage = damage
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        target_id = intent.get("target_id")
+        if not target_id or target_id not in world.npcs:
+            return False
+        attacker_loc = world.find_npc_location(actor.id)
+        target_loc = world.find_npc_location(target_id)
+        return attacker_loc is not None and attacker_loc == target_loc
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="attack",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["target_id"]],
+                payload={"damage": self.damage},
+            )
+        ]

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -102,3 +102,8 @@ class WorldState:
             if loc_id and item_id in self.locations_state[loc_id].items:
                 self.locations_state[loc_id].items.remove(item_id)
                 self.npcs[actor_id].inventory.append(item_id)
+        elif event.event_type == "attack":
+            target_id = event.target_ids[0]
+            damage = event.payload.get("damage", 0)
+            if target_id in self.npcs:
+                self.npcs[target_id].hp -= damage

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -9,6 +9,7 @@ from engine.simulator import Simulator
 from engine.tools.move import MoveTool
 from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
+from engine.tools.attack import AttackTool
 
 
 def main():
@@ -19,9 +20,10 @@ def main():
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())
+    sim.register_tool(AttackTool())
 
     actor_id = "npc_sample"  # temporary player actor
-    print("Type 'look', 'move <location_id>', 'grab <item_id>' or 'quit'.")
+    print("Type 'look', 'move <location_id>', 'grab <item_id>', 'attack <npc_id>' or 'quit'.")
     while True:
         cmd = input("-> ").strip()
         if not cmd:
@@ -36,6 +38,9 @@ def main():
         elif cmd.startswith("grab "):
             item = cmd.split(" ", 1)[1]
             command = {"tool": "grab", "params": {"item_id": item}}
+        elif cmd.startswith("attack "):
+            target = cmd.split(" ", 1)[1]
+            command = {"tool": "attack", "params": {"target_id": target}}
         else:
             print("Unknown command")
             continue


### PR DESCRIPTION
## Summary
- implement `AttackTool` with simple damage logic
- extend `Simulator` and `WorldState` to handle attack events
- update CLI game to use the new tool
- populate a sample enemy NPC and place them in town square

## Testing
- `python scripts/test_loader.py`
- `python scripts/demo_simulator.py`
- `python scripts/cli_game.py <<'EOF'
attack npc_enemy
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688bea1d2978832e82c91bb2ea4d14b5