### PR TITLE
Implement talk tool and update progress

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -17,10 +17,17 @@ This document tracks the implementation status of the engine against the design 
     beginnings of the Action‑Time system.
   - `scripts/cli_game.py` implements an interactive command loop.
 
+- **Phase 3 – LLM Command Parser**
+  - `engine/llm_client.py` connects to an OpenAI-compatible endpoint.
+  - `scripts/cli_game.py` can use the LLM to parse free text when `--llm` is supplied.
+
+- **Phase 4 – Additional Tools**
+  - A basic `attack` tool allows damaging other actors.
+  - A `talk` tool enables simple speech output.
+
 ## Outstanding Tasks
 
-- Integrate an LLM command parser (Phase 3). A basic `LLMClient` stub and optional
-  LLM mode for the CLI game are next.
+- Flesh out deterministic combat resolution beyond fixed damage.
 - Add more tools (attack, talk, etc.) and deterministic combat handling (Phase 4).
 - Implement NPC AI with memory and conversation systems (Phase 5).
 - Build polish features such as the narrator, fallback system and tag rules.

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -58,5 +58,13 @@ class Simulator:
             target = self.world.get_npc(event.target_ids[0])
             dmg = event.payload.get("damage", 0)
             print(f"{attacker.name} hits {target.name} for {dmg} damage (HP: {target.hp})")
+        elif event.event_type == "talk":
+            speaker = self.world.get_npc(event.actor_id)
+            content = event.payload.get("content", "")
+            if event.target_ids:
+                target = self.world.get_npc(event.target_ids[0])
+                print(f"{speaker.name} to {target.name}: {content}")
+            else:
+                print(f"{speaker.name} says: {content}")
         else:
             self.world.apply_event(event)

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -2,10 +2,12 @@ from .move import MoveTool
 from .look import LookTool
 from .grab import GrabTool
 from .attack import AttackTool
+from .talk import TalkTool
 
 __all__ = [
     "MoveTool",
     "LookTool",
     "GrabTool",
     "AttackTool",
+    "TalkTool",
 ]

--- a/engine/tools/talk.py
+++ b/engine/tools/talk.py
@@ -1,0 +1,38 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class TalkTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="talk", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        # Expect at least 'content' string; optional 'target_id'
+        content = intent.get("content")
+        if not isinstance(content, str) or not content:
+            return False
+        target = intent.get("target_id")
+        if target is not None and target not in world.npcs:
+            return False
+        # ensure speaker and target share location if target given
+        if target:
+            actor_loc = world.find_npc_location(actor.id)
+            target_loc = world.find_npc_location(target)
+            if actor_loc != target_loc:
+                return False
+        return True
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="talk",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent.get("target_id")] if intent.get("target_id") else [],
+                payload={"content": intent["content"]},
+            )
+        ]


### PR DESCRIPTION
## Summary
- implement `TalkTool` and register it
- handle `talk` events in the simulator
- extend CLI game to parse `talk` commands
- document progress up to LLM integration and new tools

## Testing
- `python3 scripts/test_loader.py`
- `python3 scripts/demo_simulator.py`
- `python3 scripts/cli_game.py <<'EOF'
look
talk Hello there!
talk npc_enemy I will fight you
attack npc_enemy
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688bf1163f34832eb14c15f36459312f