### PR TITLE
Add simple narrator component

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -3,5 +3,6 @@
 from .world_state import WorldState
 from .simulator import Simulator
 from .llm_client import LLMClient
+from .narrator import Narrator
 
-__all__ = ["WorldState", "Simulator", "LLMClient"]
+__all__ = ["WorldState", "Simulator", "LLMClient", "Narrator"]

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+
+from .events import Event
+from .world_state import WorldState
+from rpg import combat_rules
+
+
+class Narrator:
+    """Simple component turning events into plain text descriptions."""
+
+    def __init__(self, world: WorldState):
+        self.world = world
+
+    def render(self, event: Event, extra: Optional[Dict[str, Any]] = None) -> str:
+        if event.event_type == "describe_location":
+            return event.payload.get("description", "")
+        elif event.event_type == "move":
+            actor = self.world.get_npc(event.actor_id)
+            loc = self.world.get_location_static(event.target_ids[0])
+            return f"{actor.name} moves to {loc.description}"
+        elif event.event_type == "grab":
+            actor = self.world.get_npc(event.actor_id)
+            item = self.world.get_item_instance(event.target_ids[0])
+            bp = self.world.get_item_blueprint(item.blueprint_id)
+            return f"{actor.name} picks up {bp.name}."
+        elif event.event_type == "attack" and extra is not None:
+            attacker = self.world.get_npc(event.actor_id)
+            target = self.world.get_npc(event.target_ids[0])
+            if extra.get("hit"):
+                return (
+                    f"{attacker.name} hits {target.name} for {extra['damage']} "
+                    f"damage (HP: {target.hp})"
+                )
+            return (
+                f"{attacker.name} misses {target.name} "
+                f"(roll {extra['to_hit']} vs AC {extra['target_ac']})"
+            )
+        elif event.event_type == "talk":
+            speaker = self.world.get_npc(event.actor_id)
+            content = event.payload.get("content", "")
+            if event.target_ids:
+                target = self.world.get_npc(event.target_ids[0])
+                return f"{speaker.name} to {target.name}: {content}"
+            return f"{speaker.name} says: {content}"
+        return ""

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from engine.world_state import WorldState
 from engine.simulator import Simulator
+from engine.narrator import Narrator
 from engine.tools.move import MoveTool
 from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
@@ -32,7 +33,8 @@ def main():
     world = WorldState(Path("data"))
     world.load()
 
-    sim = Simulator(world)
+    narrator = Narrator(world)
+    sim = Simulator(world, narrator=narrator)
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())

--- a/scripts/demo_simulator.py
+++ b/scripts/demo_simulator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from engine.world_state import WorldState
 from engine.simulator import Simulator
+from engine.narrator import Narrator
 from engine.tools.move import MoveTool
 from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
@@ -11,7 +12,8 @@ from engine.tools.grab import GrabTool
 def main():
     world = WorldState(Path("data"))
     world.load()
-    sim = Simulator(world)
+    narrator = Narrator(world)
+    sim = Simulator(world, narrator=narrator)
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())


### PR DESCRIPTION
## Summary
- introduce `Narrator` for translating events to text
- use `Narrator` in `Simulator`
- update CLI and demo scripts

## Testing
- `python scripts/demo_simulator.py`
- `python scripts/cli_game.py <<'EOF'
look
quit
EOF`
- `python scripts/test_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf8050e34832e940294063b3ab879