### PR TITLE
Add item ownership fields

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -23,7 +23,10 @@ This document tracks the implementation status of the engine against the design 
 
 - **Phase 4 – Additional Tools**
   - A basic `attack` tool allows damaging other actors.
-  - A `talk` tool enables simple speech output.
+- A `talk` tool enables simple speech output.
+- Item instances now store `current_location`, `owner_id`, `item_state`,
+  `inventory` and `tags` fields. The `WorldState` assigns locations to items on
+  load and updates ownership when items are grabbed.
 
 ## Outstanding Tasks
 

--- a/data/items/instances/item_leather_armor_1.json
+++ b/data/items/instances/item_leather_armor_1.json
@@ -1,4 +1,9 @@
 {
   "id": "item_leather_armor_1",
-  "blueprint_id": "leather_armor"
+  "blueprint_id": "leather_armor",
+  "current_location": null,
+  "owner_id": "npc_enemy",
+  "item_state": {},
+  "inventory": [],
+  "tags": {"inherent": [], "dynamic": []}
 }

--- a/data/items/instances/item_rusty_sword_1.json
+++ b/data/items/instances/item_rusty_sword_1.json
@@ -1,4 +1,9 @@
 {
   "id": "item_rusty_sword_1",
-  "blueprint_id": "rusty_sword"
+  "blueprint_id": "rusty_sword",
+  "current_location": "market_square",
+  "owner_id": null,
+  "item_state": {},
+  "inventory": [],
+  "tags": {"inherent": [], "dynamic": []}
 }

--- a/engine/data_models.py
+++ b/engine/data_models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 
 @dataclass
@@ -53,3 +53,8 @@ class ItemBlueprint:
 class ItemInstance:
     id: str
     blueprint_id: str
+    current_location: Optional[str] = None
+    owner_id: Optional[str] = None
+    item_state: Dict[str, Any] = field(default_factory=dict)
+    inventory: List[str] = field(default_factory=list)
+    tags: Dict[str, List[str]] = field(default_factory=lambda: {"inherent": [], "dynamic": []})

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from .data_models import (
     NPC,
@@ -24,6 +24,12 @@ class WorldState:
         self._load_npcs()
         self._load_locations()
         self._load_items()
+        # assign current_location for items based on location state
+        for loc_id, state in self.locations_state.items():
+            for item_id in state.items:
+                inst = self.item_instances.get(item_id)
+                if inst and inst.current_location is None:
+                    inst.current_location = loc_id
 
     def _load_npcs(self):
         npcs_dir = self.data_dir / "npcs"
@@ -102,3 +108,7 @@ class WorldState:
             if loc_id and item_id in self.locations_state[loc_id].items:
                 self.locations_state[loc_id].items.remove(item_id)
                 self.npcs[actor_id].inventory.append(item_id)
+                inst = self.item_instances.get(item_id)
+                if inst:
+                    inst.owner_id = actor_id
+                    inst.current_location = None


### PR DESCRIPTION
## Summary
- extend `ItemInstance` dataclass with ownership/location fields
- update `WorldState` loading and grab handler
- expand sample item JSON files
- update roadmap progress

## Testing
- `python scripts/test_loader.py`
- `python scripts/demo_simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf9e42818832ea920fc32464d366c