### PR TITLE
Add drop tool for releasing items

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -32,6 +32,7 @@ This document tracks the implementation status of the engine against the design 
 - `cli_game.py` has a `mem` command to inspect the player's recent memories.
 - Combat resolution now follows the ATTACK_ATTEMPT -> ATTACK_HIT/MISSED ->
   DAMAGE_APPLIED event chain with deterministic rules in `rpg/combat_rules.py`.
+- A `drop` tool lets actors place carried items in their current location.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -25,6 +25,11 @@ class Narrator:
             item = self.world.get_item_instance(event.target_ids[0])
             bp = self.world.get_item_blueprint(item.blueprint_id)
             return f"{actor.name} picks up {bp.name}."
+        elif event.event_type == "drop":
+            actor = self.world.get_npc(event.actor_id)
+            item = self.world.get_item_instance(event.target_ids[0])
+            bp = self.world.get_item_blueprint(item.blueprint_id)
+            return f"{actor.name} drops {bp.name}."
         elif event.event_type == "attack_attempt":
             attacker = self.world.get_npc(event.actor_id)
             target = self.world.get_npc(event.target_ids[0])

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -56,6 +56,11 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "drop":
+            self.world.apply_event(event)
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         elif event.event_type == "attack_attempt":
             attacker = self.world.get_npc(event.actor_id)
             target = self.world.get_npc(event.target_ids[0])

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -4,6 +4,7 @@ from .grab import GrabTool
 from .attack import AttackTool
 from .talk import TalkTool
 from .inventory import InventoryTool
+from .drop import DropTool
 
 __all__ = [
     "MoveTool",
@@ -12,4 +13,5 @@ __all__ = [
     "AttackTool",
     "TalkTool",
     "InventoryTool",
+    "DropTool",
 ]

--- a/engine/tools/drop.py
+++ b/engine/tools/drop.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class DropTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="drop", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        item_id = intent.get("item_id")
+        return bool(item_id in actor.inventory)
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="drop",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["item_id"]],
+            )
+        ]

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -112,6 +112,17 @@ class WorldState:
                 if inst:
                     inst.owner_id = actor_id
                     inst.current_location = None
+        elif event.event_type == "drop":
+            actor_id = event.actor_id
+            item_id = event.target_ids[0]
+            loc_id = self.find_npc_location(actor_id)
+            if loc_id and item_id in self.npcs[actor_id].inventory:
+                self.npcs[actor_id].inventory.remove(item_id)
+                self.locations_state[loc_id].items.append(item_id)
+                inst = self.item_instances.get(item_id)
+                if inst:
+                    inst.owner_id = None
+                    inst.current_location = loc_id
         elif event.event_type == "damage_applied":
             target_id = event.target_ids[0]
             amount = event.payload.get("amount", 0)

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -16,13 +16,14 @@ from engine.tools.grab import GrabTool
 from engine.tools.attack import AttackTool
 from engine.tools.talk import TalkTool
 from engine.tools.inventory import InventoryTool
+from engine.tools.drop import DropTool
 from engine.llm_client import LLMClient
 
 
 SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
-    "Available tools: look, move(target_location), grab(item_id), attack(target_id), talk(content, target_id), inventory()."
+    "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), talk(content, target_id), inventory()."
 )
 
 
@@ -39,6 +40,7 @@ def main():
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())
+    sim.register_tool(DropTool())
     sim.register_tool(AttackTool())
     sim.register_tool(TalkTool())
     sim.register_tool(InventoryTool())
@@ -48,7 +50,7 @@ def main():
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -71,6 +73,9 @@ def main():
             elif cmd.startswith("grab "):
                 item = cmd.split(" ", 1)[1]
                 command = {"tool": "grab", "params": {"item_id": item}}
+            elif cmd.startswith("drop "):
+                item = cmd.split(" ", 1)[1]
+                command = {"tool": "drop", "params": {"item_id": item}}
             elif cmd.startswith("attack "):
                 target = cmd.split(" ", 1)[1]
                 command = {"tool": "attack", "params": {"target_id": target}}

--- a/scripts/demo_simulator.py
+++ b/scripts/demo_simulator.py
@@ -7,6 +7,7 @@ from engine.narrator import Narrator
 from engine.tools.move import MoveTool
 from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
+from engine.tools.drop import DropTool
 
 
 def main():
@@ -17,6 +18,7 @@ def main():
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())
+    sim.register_tool(DropTool())
 
     print("Initial location occupants:")
     for loc_id, loc in world.locations_state.items():
@@ -31,11 +33,16 @@ def main():
     sim.process_command("npc_sample", grab_cmd)
     sim.tick()
 
+    drop_cmd = {"tool": "drop", "params": {"item_id": "item_rusty_sword_1"}}
+    sim.process_command("npc_sample", drop_cmd)
+    sim.tick()
+
     print("After move:")
     for loc_id, loc in world.locations_state.items():
         print(loc_id, loc.occupants)
 
-    print("Inventory after grab:", world.get_npc("npc_sample").inventory)
+    print("Inventory after drop:", world.get_npc("npc_sample").inventory)
+    print("Location items after drop:", world.get_location_state("market_square").items)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `DropTool` so actors can drop items in their location
- wire drop events into the world state, simulator, narrator, CLI, and demo
- document progress of new tool in the roadmap

## Testing
- `python scripts/test_loader.py`
- `python scripts/demo_simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_688f95d3a85c832e908c44a889001cf9