### PR TITLE
Add stats tool for actor attributes

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -33,6 +33,7 @@ This document tracks the implementation status of the engine against the design 
 - Combat resolution now follows the ATTACK_ATTEMPT -> ATTACK_HIT/MISSED ->
   DAMAGE_APPLIED event chain with deterministic rules in `rpg/combat_rules.py`.
 - A `drop` tool lets actors place carried items in their current location.
+- A `stats` tool reports an actor's hit points, attributes and skills.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -67,4 +67,17 @@ class Narrator:
             if items:
                 return f"{actor.name} carries: {', '.join(items)}"
             return f"{actor.name} carries nothing."
+        elif event.event_type == "stats":
+            actor = self.world.get_npc(event.actor_id)
+            hp = event.payload.get("hp", 0)
+            attrs = event.payload.get("attributes", {})
+            skills = event.payload.get("skills", {})
+            parts = [f"HP: {hp}"]
+            if attrs:
+                attr_str = ", ".join(f"{k}: {v}" for k, v in attrs.items())
+                parts.append(f"Attributes: {attr_str}")
+            if skills:
+                skill_str = ", ".join(f"{k} ({v})" for k, v in skills.items())
+                parts.append(f"Skills: {skill_str}")
+            return f"{actor.name} stats - " + "; ".join(parts)
         return ""

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -126,6 +126,10 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "stats":
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         else:
             self.world.apply_event(event)
         # After applying and narrating, record perception for nearby actors

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -5,6 +5,7 @@ from .attack import AttackTool
 from .talk import TalkTool
 from .inventory import InventoryTool
 from .drop import DropTool
+from .stats import StatsTool
 
 __all__ = [
     "MoveTool",
@@ -14,4 +15,5 @@ __all__ = [
     "TalkTool",
     "InventoryTool",
     "DropTool",
+    "StatsTool",
 ]

--- a/engine/tools/stats.py
+++ b/engine/tools/stats.py
@@ -1,0 +1,28 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class StatsTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="stats", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        return True
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="stats",
+                tick=tick,
+                actor_id=actor.id,
+                payload={
+                    "hp": actor.hp,
+                    "attributes": actor.attributes,
+                    "skills": actor.skills,
+                },
+            )
+        ]

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -17,13 +17,14 @@ from engine.tools.attack import AttackTool
 from engine.tools.talk import TalkTool
 from engine.tools.inventory import InventoryTool
 from engine.tools.drop import DropTool
+from engine.tools.stats import StatsTool
 from engine.llm_client import LLMClient
 
 
 SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
-    "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), talk(content, target_id), inventory()."
+    "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), talk(content, target_id), inventory(), stats()."
 )
 
 
@@ -44,13 +45,14 @@ def main():
     sim.register_tool(AttackTool())
     sim.register_tool(TalkTool())
     sim.register_tool(InventoryTool())
+    sim.register_tool(StatsTool())
 
     actor_id = "npc_sample"  # temporary player actor
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'stats', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -100,6 +102,8 @@ def main():
                     continue
             elif cmd in {"inventory", "inv"}:
                 command = {"tool": "inventory", "params": {}}
+            elif cmd == "stats":
+                command = {"tool": "stats", "params": {}}
             elif cmd == "mem":
                 npc = world.get_npc(actor_id)
                 for mem in npc.short_term_memory:


### PR DESCRIPTION
## Summary
- add StatsTool to display actor HP, attributes and skills
- wire stats tool into simulator and CLI
- document stats tool in roadmap progress

## Testing
- `python -m pytest`
- `python scripts/test_loader.py`
- `printf "stats\nquit\n" | python scripts/cli_game.py`


------
https://chatgpt.com/codex/tasks/task_e_688f97131750832ea6d21080e8fb8ce5