### PR TITLE
feat: show items and actors when looking

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -35,6 +35,7 @@ This document tracks the implementation status of the engine against the design 
 - A `drop` tool lets actors place carried items in their current location.
 - A `stats` tool reports an actor's hit points, attributes and skills.
 - `equip` and `unequip` tools let actors manage equipment slots.
+- `look` now reports visible items and other actors in the location.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -15,7 +15,15 @@ class Narrator:
 
     def render(self, event: Event, extra: Optional[Dict[str, Any]] = None) -> str:
         if event.event_type == "describe_location":
-            return event.payload.get("description", "")
+            description = event.payload.get("description", "")
+            occupants = event.payload.get("occupants", [])
+            items = event.payload.get("items", [])
+            parts = [description]
+            if occupants:
+                parts.append("You see: " + ", ".join(occupants))
+            if items:
+                parts.append("Items here: " + ", ".join(items))
+            return " ".join(parts).strip()
         elif event.event_type == "move":
             actor = self.world.get_npc(event.actor_id)
             loc = self.world.get_location_static(event.target_ids[0])


### PR DESCRIPTION
## Summary
- enrich Look tool to include visible items and other actors
- Narrator now describes items and actors in location
- document progress for improved look behavior

## Testing
- `python scripts/test_loader.py`
- `python scripts/demo_simulator.py`
- `python scripts/cli_game.py <<'EOF'
look
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688f99a6f9ac832e8e19feb20eb31a7c