### PR TITLE
Add analyze tool for inspecting items

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -36,6 +36,7 @@ This document tracks the implementation status of the engine against the design 
 - A `stats` tool reports an actor's hit points, attributes and skills.
 - `equip` and `unequip` tools let actors manage equipment slots.
 - `look` now reports visible items and other actors in the location.
+- An `analyze` tool reports item details.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -100,4 +100,19 @@ class Narrator:
             bp = self.world.get_item_blueprint(item.blueprint_id)
             slot = event.payload.get("slot", "")
             return f"{actor.name} removes {bp.name} from {slot}."
+        elif event.event_type == "analyze":
+            name = event.payload.get("name", "")
+            weight = event.payload.get("weight")
+            damage = event.payload.get("damage_dice")
+            dmg_type = event.payload.get("damage_type")
+            armour = event.payload.get("armour_rating")
+            props = event.payload.get("properties", [])
+            parts = [f"{name} (weight {weight})"]
+            if damage:
+                parts.append(f"Damage: {damage} {dmg_type}")
+            if armour:
+                parts.append(f"Armour rating: {armour}")
+            if props:
+                parts.append("Properties: " + ", ".join(props))
+            return " ".join(parts)
         return ""

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -140,6 +140,10 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "analyze":
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         else:
             self.world.apply_event(event)
         # After applying and narrating, record perception for nearby actors

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -8,6 +8,7 @@ from .drop import DropTool
 from .stats import StatsTool
 from .equip import EquipTool
 from .unequip import UnequipTool
+from .analyze import AnalyzeTool
 
 __all__ = [
     "MoveTool",
@@ -20,4 +21,5 @@ __all__ = [
     "StatsTool",
     "EquipTool",
     "UnequipTool",
+    "AnalyzeTool",
 ]

--- a/engine/tools/analyze.py
+++ b/engine/tools/analyze.py
@@ -1,0 +1,47 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class AnalyzeTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="analyze", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        item_id = intent.get("item_id")
+        if not item_id:
+            return False
+        if item_id in actor.inventory:
+            return True
+        loc_id = world.find_npc_location(actor.id)
+        if not loc_id:
+            return False
+        loc_state = world.get_location_state(loc_id)
+        return item_id in loc_state.items
+
+    def generate_events(
+        self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int
+    ) -> List[Event]:
+        item_id = intent["item_id"]
+        inst = world.get_item_instance(item_id)
+        bp = world.get_item_blueprint(inst.blueprint_id)
+        payload = {
+            "name": bp.name,
+            "weight": bp.weight,
+            "damage_dice": bp.damage_dice,
+            "damage_type": bp.damage_type,
+            "armour_rating": bp.armour_rating,
+            "properties": bp.properties,
+        }
+        return [
+            Event(
+                event_type="analyze",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[item_id],
+                payload=payload,
+            )
+        ]

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -20,6 +20,7 @@ from engine.tools.drop import DropTool
 from engine.tools.stats import StatsTool
 from engine.tools.equip import EquipTool
 from engine.tools.unequip import UnequipTool
+from engine.tools.analyze import AnalyzeTool
 from engine.llm_client import LLMClient
 
 
@@ -27,7 +28,7 @@ SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
-    "talk(content, target_id), inventory(), stats(), equip(item_id, slot), unequip(slot)."
+    "talk(content, target_id), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id)."
 )
 
 
@@ -51,13 +52,14 @@ def main():
     sim.register_tool(StatsTool())
     sim.register_tool(EquipTool())
     sim.register_tool(UnequipTool())
+    sim.register_tool(AnalyzeTool())
 
     actor_id = "npc_sample"  # temporary player actor
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -109,6 +111,9 @@ def main():
                 command = {"tool": "inventory", "params": {}}
             elif cmd == "stats":
                 command = {"tool": "stats", "params": {}}
+            elif cmd.startswith("analyze "):
+                item = cmd.split(" ", 1)[1]
+                command = {"tool": "analyze", "params": {"item_id": item}}
             elif cmd.startswith("equip "):
                 parts = cmd.split()
                 if len(parts) == 3:


### PR DESCRIPTION
## Summary
- add `AnalyzeTool` for inspecting item statistics
- handle and narrate `analyze` events
- expose `analyze` command in CLI and roadmap

## Testing
- `python scripts/test_loader.py`
- `printf 'move market_square
analyze item_rusty_sword_1
quit
' | python scripts/cli_game.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9afee05c832e829c4a9b4a57e9ef