### PR TITLE
Add scream tool with sound propagation

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -37,6 +37,7 @@ This document tracks the implementation status of the engine against the design 
 - `equip` and `unequip` tools let actors manage equipment slots.
 - `look` now reports visible items and other actors in the location.
 - An `analyze` tool reports item details.
+- A `scream` tool lets actors broadcast messages; nearby NPCs record the event in their memories.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -69,6 +69,10 @@ class Narrator:
                 target = self.world.get_npc(event.target_ids[0])
                 return f"{speaker.name} to {target.name}: {content}"
             return f"{speaker.name} says: {content}"
+        elif event.event_type == "scream":
+            speaker = self.world.get_npc(event.actor_id)
+            content = event.payload.get("content", "")
+            return f"{speaker.name} screams: {content}"
         elif event.event_type == "inventory":
             actor = self.world.get_npc(event.actor_id)
             items = event.payload.get("items", [])

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -122,6 +122,10 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "scream":
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         elif event.event_type == "inventory":
             msg = self.narrator.render(event)
             if msg:
@@ -162,10 +166,20 @@ class Simulator:
         if not location_id:
             return
 
+        recipients = set()
         loc_state = self.world.get_location_state(location_id)
         for npc_id in loc_state.occupants:
-            if npc_id == event.actor_id:
-                continue
+            if npc_id != event.actor_id:
+                recipients.add(npc_id)
+
+        if event.event_type == "scream":
+            loc_static = self.world.get_location_static(location_id)
+            for neighbor_id in loc_static.hex_connections.values():
+                neighbor_state = self.world.get_location_state(neighbor_id)
+                for npc_id in neighbor_state.occupants:
+                    recipients.add(npc_id)
+
+        for npc_id in recipients:
             npc = self.world.get_npc(npc_id)
             npc.short_term_memory.append(
                 {

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -3,6 +3,7 @@ from .look import LookTool
 from .grab import GrabTool
 from .attack import AttackTool
 from .talk import TalkTool
+from .scream import ScreamTool
 from .inventory import InventoryTool
 from .drop import DropTool
 from .stats import StatsTool
@@ -16,6 +17,7 @@ __all__ = [
     "GrabTool",
     "AttackTool",
     "TalkTool",
+    "ScreamTool",
     "InventoryTool",
     "DropTool",
     "StatsTool",

--- a/engine/tools/scream.py
+++ b/engine/tools/scream.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class ScreamTool(Tool):
+    """Broadcast a loud shout that can be heard in adjacent locations."""
+
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="scream", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        content = intent.get("content")
+        return isinstance(content, str) and bool(content)
+
+    def generate_events(
+        self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int
+    ) -> List[Event]:
+        return [
+            Event(
+                event_type="scream",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[],
+                payload={"content": intent["content"]},
+            )
+        ]

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -15,6 +15,7 @@ from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
 from engine.tools.attack import AttackTool
 from engine.tools.talk import TalkTool
+from engine.tools.scream import ScreamTool
 from engine.tools.inventory import InventoryTool
 from engine.tools.drop import DropTool
 from engine.tools.stats import StatsTool
@@ -28,7 +29,7 @@ SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
-    "talk(content, target_id), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id)."
+    "talk(content, target_id), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id)."
 )
 
 
@@ -48,6 +49,7 @@ def main():
     sim.register_tool(DropTool())
     sim.register_tool(AttackTool())
     sim.register_tool(TalkTool())
+    sim.register_tool(ScreamTool())
     sim.register_tool(InventoryTool())
     sim.register_tool(StatsTool())
     sim.register_tool(EquipTool())
@@ -59,7 +61,7 @@ def main():
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -107,6 +109,9 @@ def main():
                 else:
                     print("Unknown command")
                     continue
+            elif cmd.startswith("scream "):
+                content = cmd.split(" ", 1)[1]
+                command = {"tool": "scream", "params": {"content": content}}
             elif cmd in {"inventory", "inv"}:
                 command = {"tool": "inventory", "params": {}}
             elif cmd == "stats":


### PR DESCRIPTION
## Summary
- Add `ScreamTool` for loud broadcast messages
- Record scream events in adjacent locations and narrate them
- Wire up scream command in CLI and update progress roadmap

## Testing
- `python scripts/test_loader.py`
- `python - <<'PY'
from pathlib import Path
from engine.world_state import WorldState
from engine.simulator import Simulator
from engine.narrator import Narrator
from engine.tools.move import MoveTool
from engine.tools.scream import ScreamTool
from engine.tools.look import LookTool
world = WorldState(Path('data'))
world.load()
sim = Simulator(world, narrator=Narrator(world))
sim.register_tool(MoveTool())
sim.register_tool(ScreamTool())
sim.register_tool(LookTool())
move_enemy = {"tool": "move", "params": {"target_location": "market_square"}}
sim.process_command("npc_enemy", move_enemy)
while sim.event_queue:
    sim.tick()
scream_cmd = {"tool": "scream", "params": {"content": "Help!"}}
sim.process_command("npc_sample", scream_cmd)
while sim.event_queue:
    sim.tick()
print('Enemy memory count:', len(world.get_npc('npc_enemy').short_term_memory))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688f9c2572d8832ea6c92fe31a19ac60