### PR TITLE
Add talk_loud tool for louder speech

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -23,21 +23,22 @@ This document tracks the implementation status of the engine against the design 
 
 - **Phase 4 – Additional Tools**
   - A basic `attack` tool allows damaging other actors.
-- A `talk` tool enables simple speech output.
-- Item instances now store `current_location`, `owner_id`, `item_state`,
-  `inventory` and `tags` fields. The `WorldState` assigns locations to items on
-  load and updates ownership when items are grabbed.
-- NPCs now record simple perception events in `short_term_memory` whenever
-  actions occur in their location.
-- `cli_game.py` has a `mem` command to inspect the player's recent memories.
-- Combat resolution now follows the ATTACK_ATTEMPT -> ATTACK_HIT/MISSED ->
-  DAMAGE_APPLIED event chain with deterministic rules in `rpg/combat_rules.py`.
-- A `drop` tool lets actors place carried items in their current location.
-- A `stats` tool reports an actor's hit points, attributes and skills.
-- `equip` and `unequip` tools let actors manage equipment slots.
-- `look` now reports visible items and other actors in the location.
-- An `analyze` tool reports item details.
-- A `scream` tool lets actors broadcast messages; nearby NPCs record the event in their memories.
+  - A `talk` tool enables simple speech output.
+  - A `talk_loud` tool lets actors shout to adjacent locations if passages are open.
+  - Item instances now store `current_location`, `owner_id`, `item_state`,
+    `inventory` and `tags` fields. The `WorldState` assigns locations to items on
+    load and updates ownership when items are grabbed.
+  - NPCs now record simple perception events in `short_term_memory` whenever
+    actions occur in their location.
+  - `cli_game.py` has a `mem` command to inspect the player's recent memories.
+  - Combat resolution now follows the ATTACK_ATTEMPT -> ATTACK_HIT/MISSED ->
+    DAMAGE_APPLIED event chain with deterministic rules in `rpg/combat_rules.py`.
+  - A `drop` tool lets actors place carried items in their current location.
+  - A `stats` tool reports an actor's hit points, attributes and skills.
+  - `equip` and `unequip` tools let actors manage equipment slots.
+  - `look` now reports visible items and other actors in the location.
+  - An `analyze` tool reports item details.
+  - A `scream` tool lets actors broadcast messages; nearby NPCs record the event in their memories.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -73,6 +73,10 @@ class Narrator:
             speaker = self.world.get_npc(event.actor_id)
             content = event.payload.get("content", "")
             return f"{speaker.name} screams: {content}"
+        elif event.event_type == "talk_loud":
+            speaker = self.world.get_npc(event.actor_id)
+            content = event.payload.get("content", "")
+            return f"{speaker.name} shouts: {content}"
         elif event.event_type == "inventory":
             actor = self.world.get_npc(event.actor_id)
             items = event.payload.get("items", [])

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -122,6 +122,10 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "talk_loud":
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         elif event.event_type == "scream":
             msg = self.narrator.render(event)
             if msg:
@@ -178,6 +182,15 @@ class Simulator:
                 neighbor_state = self.world.get_location_state(neighbor_id)
                 for npc_id in neighbor_state.occupants:
                     recipients.add(npc_id)
+        elif event.event_type == "talk_loud":
+            loc_static = self.world.get_location_static(location_id)
+            loc_state = self.world.get_location_state(location_id)
+            for neighbor_id in loc_static.hex_connections.values():
+                conn = loc_state.connections_state.get(neighbor_id, {})
+                if conn.get("status", "open") == "open":
+                    neighbor_state = self.world.get_location_state(neighbor_id)
+                    for npc_id in neighbor_state.occupants:
+                        recipients.add(npc_id)
 
         for npc_id in recipients:
             npc = self.world.get_npc(npc_id)

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -3,6 +3,7 @@ from .look import LookTool
 from .grab import GrabTool
 from .attack import AttackTool
 from .talk import TalkTool
+from .talk_loud import TalkLoudTool
 from .scream import ScreamTool
 from .inventory import InventoryTool
 from .drop import DropTool
@@ -17,6 +18,7 @@ __all__ = [
     "GrabTool",
     "AttackTool",
     "TalkTool",
+    "TalkLoudTool",
     "ScreamTool",
     "InventoryTool",
     "DropTool",

--- a/engine/tools/talk_loud.py
+++ b/engine/tools/talk_loud.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class TalkLoudTool(Tool):
+    """Speak loudly so adjacent locations with open connections can hear."""
+
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="talk_loud", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        content = intent.get("content")
+        return isinstance(content, str) and bool(content)
+
+    def generate_events(
+        self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int
+    ) -> List[Event]:
+        return [
+            Event(
+                event_type="talk_loud",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[],
+                payload={"content": intent["content"]},
+            )
+        ]

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -15,6 +15,7 @@ from engine.tools.look import LookTool
 from engine.tools.grab import GrabTool
 from engine.tools.attack import AttackTool
 from engine.tools.talk import TalkTool
+from engine.tools.talk_loud import TalkLoudTool
 from engine.tools.scream import ScreamTool
 from engine.tools.inventory import InventoryTool
 from engine.tools.drop import DropTool
@@ -29,7 +30,7 @@ SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
-    "talk(content, target_id), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id)."
+    "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id)."
 )
 
 
@@ -49,6 +50,7 @@ def main():
     sim.register_tool(DropTool())
     sim.register_tool(AttackTool())
     sim.register_tool(TalkTool())
+    sim.register_tool(TalkLoudTool())
     sim.register_tool(ScreamTool())
     sim.register_tool(InventoryTool())
     sim.register_tool(StatsTool())
@@ -61,7 +63,7 @@ def main():
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -112,6 +114,9 @@ def main():
             elif cmd.startswith("scream "):
                 content = cmd.split(" ", 1)[1]
                 command = {"tool": "scream", "params": {"content": content}}
+            elif cmd.startswith("shout "):
+                content = cmd.split(" ", 1)[1]
+                command = {"tool": "talk_loud", "params": {"content": content}}
             elif cmd in {"inventory", "inv"}:
                 command = {"tool": "inventory", "params": {}}
             elif cmd == "stats":


### PR DESCRIPTION
## Summary
- Add `talk_loud` tool that shouts to adjacent locations when paths are open
- Handle new `talk_loud` events in simulator and narrator
- Extend CLI with `shout` command and update roadmap

## Testing
- `python scripts/test_loader.py`
- `python -m py_compile engine/tools/talk_loud.py engine/narrator.py engine/simulator.py engine/tools/__init__.py scripts/cli_game.py`
- `python - <<'PY'
from pathlib import Path
from engine.world_state import WorldState
from engine.simulator import Simulator
from engine.narrator import Narrator
from engine.tools.talk_loud import TalkLoudTool

world = WorldState(Path('data'))
world.load()
# Move npc_enemy to market_square to test adjacency
world.locations_state['town_square'].occupants.remove('npc_enemy')
world.locations_state['market_square'].occupants.append('npc_enemy')

sim = Simulator(world, narrator=Narrator(world))
sim.register_tool(TalkLoudTool())

sim.process_command('npc_sample', {'tool': 'talk_loud', 'params': {'content': 'hello there'}})
while sim.event_queue:
    sim.tick()

print(world.get_npc('npc_enemy').short_term_memory)
PY`
- `printf "shout hi\nquit\n" | python scripts/cli_game.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9dd96ddc832eb6fee2cc877384ac