### PR TITLE
Add give tool for item transfers

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -41,6 +41,7 @@ This document tracks the implementation status of the engine against the design 
   - A `scream` tool lets actors broadcast messages; nearby NPCs record the event in their memories.
   - A basic hunger system tracks when actors last ate and updates their hunger stage each tick.
   - An `eat` tool allows consuming food items to reset hunger.
+  - A `give` tool transfers items between actors occupying the same location.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -130,4 +130,10 @@ class Narrator:
             if props:
                 parts.append("Properties: " + ", ".join(props))
             return " ".join(parts)
+        elif event.event_type == "give":
+            actor = self.world.get_npc(event.actor_id)
+            item = self.world.get_item_instance(event.target_ids[0])
+            target = self.world.get_npc(event.target_ids[1])
+            bp = self.world.get_item_blueprint(item.blueprint_id)
+            return f"{actor.name} gives {bp.name} to {target.name}."
         return ""

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -158,6 +158,11 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "give":
+            self.world.apply_event(event)
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         else:
             self.world.apply_event(event)
         # After applying and narrating, record perception for nearby actors

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -12,6 +12,7 @@ from .equip import EquipTool
 from .unequip import UnequipTool
 from .analyze import AnalyzeTool
 from .eat import EatTool
+from .give import GiveTool
 
 __all__ = [
     "MoveTool",
@@ -28,4 +29,5 @@ __all__ = [
     "UnequipTool",
     "AnalyzeTool",
     "EatTool",
+    "GiveTool",
 ]

--- a/engine/tools/give.py
+++ b/engine/tools/give.py
@@ -1,0 +1,34 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class GiveTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="give", time_cost=time_cost)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        item_id = intent.get("item_id")
+        target_id = intent.get("target_id")
+        if not item_id or not target_id:
+            return False
+        if item_id not in actor.inventory:
+            return False
+        if target_id not in world.npcs:
+            return False
+        actor_loc = world.find_npc_location(actor.id)
+        target_loc = world.find_npc_location(target_id)
+        return actor_loc is not None and actor_loc == target_loc
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        return [
+            Event(
+                event_type="give",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["item_id"], intent["target_id"]],
+            )
+        ]

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -173,3 +173,14 @@ class WorldState:
                 item_id = npc.slots[slot]
                 npc.inventory.append(item_id)
                 npc.slots[slot] = None
+        elif event.event_type == "give":
+            actor_id = event.actor_id
+            item_id, target_id = event.target_ids
+            giver = self.npcs.get(actor_id)
+            receiver = self.npcs.get(target_id)
+            if giver and receiver and item_id in giver.inventory:
+                giver.inventory.remove(item_id)
+                receiver.inventory.append(item_id)
+                inst = self.item_instances.get(item_id)
+                if inst:
+                    inst.owner_id = target_id

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -24,6 +24,7 @@ from engine.tools.equip import EquipTool
 from engine.tools.unequip import UnequipTool
 from engine.tools.analyze import AnalyzeTool
 from engine.tools.eat import EatTool
+from engine.tools.give import GiveTool
 from engine.llm_client import LLMClient
 
 
@@ -31,7 +32,7 @@ SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
-    "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id), eat(item_id)."
+    "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id), eat(item_id), give(item_id, target_id)."
 )
 
 
@@ -59,13 +60,14 @@ def main():
     sim.register_tool(UnequipTool())
     sim.register_tool(AnalyzeTool())
     sim.register_tool(EatTool())
+    sim.register_tool(GiveTool())
 
     actor_id = "npc_sample"  # temporary player actor
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'eat <item>', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'eat <item>', 'give <item> <npc>', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -129,6 +131,14 @@ def main():
             elif cmd.startswith("eat "):
                 item = cmd.split(" ", 1)[1]
                 command = {"tool": "eat", "params": {"item_id": item}}
+            elif cmd.startswith("give "):
+                parts = cmd.split()
+                if len(parts) == 3:
+                    item, target = parts[1], parts[2]
+                    command = {"tool": "give", "params": {"item_id": item, "target_id": target}}
+                else:
+                    print("Usage: give <item_id> <npc_id>")
+                    continue
             elif cmd.startswith("equip "):
                 parts = cmd.split()
                 if len(parts) == 3:


### PR DESCRIPTION
## Summary
- add GiveTool for transferring items between actors
- narrate and apply `give` events in world state and simulator
- wire up new `give` command in CLI and update progress doc

## Testing
- `python scripts/test_loader.py`
- `python scripts/cli_game.py <<'EOF'
look
move market_square
look
grab item_rusty_sword_1
move town_square
give item_rusty_sword_1 npc_enemy
inventory
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_688fa1044bcc832e85fbf8af0ef6d71d