### PR TITLE
Add door open/close tools and connection-aware movement

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -42,6 +42,7 @@ This document tracks the implementation status of the engine against the design 
   - A basic hunger system tracks when actors last ate and updates their hunger stage each tick.
   - An `eat` tool allows consuming food items to reset hunger.
   - A `give` tool transfers items between actors occupying the same location.
+  - `open` and `close` tools toggle passage status between locations, and `move` respects closed connections.
 
 ## Outstanding Tasks
 

--- a/data/locations/market_square_state.json
+++ b/data/locations/market_square_state.json
@@ -7,5 +7,7 @@
   ],
   "sublocations": [],
   "transient_effects": [],
-  "connections_state": {}
+  "connections_state": {
+    "town_square": {"status": "closed"}
+  }
 }

--- a/data/locations/town_square_state.json
+++ b/data/locations/town_square_state.json
@@ -4,5 +4,7 @@
   "items": [],
   "sublocations": [],
   "transient_effects": [],
-  "connections_state": {}
+  "connections_state": {
+    "market_square": {"status": "closed"}
+  }
 }

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -136,4 +136,12 @@ class Narrator:
             target = self.world.get_npc(event.target_ids[1])
             bp = self.world.get_item_blueprint(item.blueprint_id)
             return f"{actor.name} gives {bp.name} to {target.name}."
+        elif event.event_type == "open_connection":
+            actor = self.world.get_npc(event.actor_id)
+            loc = self.world.get_location_static(event.target_ids[0])
+            return f"{actor.name} opens the way to {loc.description}."
+        elif event.event_type == "close_connection":
+            actor = self.world.get_npc(event.actor_id)
+            loc = self.world.get_location_static(event.target_ids[0])
+            return f"{actor.name} closes the way to {loc.description}."
         return ""

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -163,6 +163,11 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type in {"open_connection", "close_connection"}:
+            self.world.apply_event(event)
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         else:
             self.world.apply_event(event)
         # After applying and narrating, record perception for nearby actors

--- a/engine/tools/close_door.py
+++ b/engine/tools/close_door.py
@@ -6,9 +6,9 @@ from ..world_state import WorldState
 from ..data_models import NPC
 
 
-class MoveTool(Tool):
-    def __init__(self, time_cost: int = 5):
-        super().__init__(name="move", time_cost=time_cost)
+class CloseDoorTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="close", time_cost=time_cost)
 
     def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
         target = intent.get("target_location")
@@ -25,9 +25,11 @@ class MoveTool(Tool):
         return conn.get("status", "open") == "open"
 
     def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
-        return [Event(
-            event_type="move",
-            tick=tick,
-            actor_id=actor.id,
-            target_ids=[intent["target_location"]],
-        )]
+        return [
+            Event(
+                event_type="close_connection",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["target_location"]],
+            )
+        ]

--- a/engine/tools/open_door.py
+++ b/engine/tools/open_door.py
@@ -6,9 +6,9 @@ from ..world_state import WorldState
 from ..data_models import NPC
 
 
-class MoveTool(Tool):
-    def __init__(self, time_cost: int = 5):
-        super().__init__(name="move", time_cost=time_cost)
+class OpenDoorTool(Tool):
+    def __init__(self, time_cost: int = 1):
+        super().__init__(name="open", time_cost=time_cost)
 
     def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
         target = intent.get("target_location")
@@ -22,12 +22,14 @@ class MoveTool(Tool):
             return False
         loc_state = world.get_location_state(current)
         conn = loc_state.connections_state.get(target, {})
-        return conn.get("status", "open") == "open"
+        return conn.get("status", "open") != "open"
 
     def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
-        return [Event(
-            event_type="move",
-            tick=tick,
-            actor_id=actor.id,
-            target_ids=[intent["target_location"]],
-        )]
+        return [
+            Event(
+                event_type="open_connection",
+                tick=tick,
+                actor_id=actor.id,
+                target_ids=[intent["target_location"]],
+            )
+        ]

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -184,3 +184,15 @@ class WorldState:
                 inst = self.item_instances.get(item_id)
                 if inst:
                     inst.owner_id = target_id
+        elif event.event_type == "open_connection":
+            actor_loc = self.find_npc_location(event.actor_id)
+            target = event.target_ids[0]
+            if actor_loc:
+                self.locations_state[actor_loc].connections_state.setdefault(target, {})["status"] = "open"
+                self.locations_state[target].connections_state.setdefault(actor_loc, {})["status"] = "open"
+        elif event.event_type == "close_connection":
+            actor_loc = self.find_npc_location(event.actor_id)
+            target = event.target_ids[0]
+            if actor_loc:
+                self.locations_state[actor_loc].connections_state.setdefault(target, {})["status"] = "closed"
+                self.locations_state[target].connections_state.setdefault(actor_loc, {})["status"] = "closed"

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -25,6 +25,8 @@ from engine.tools.unequip import UnequipTool
 from engine.tools.analyze import AnalyzeTool
 from engine.tools.eat import EatTool
 from engine.tools.give import GiveTool
+from engine.tools.open_door import OpenDoorTool
+from engine.tools.close_door import CloseDoorTool
 from engine.llm_client import LLMClient
 
 
@@ -32,7 +34,7 @@ SYSTEM_PROMPT = (
     "You are a command parser for a text game. "
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
-    "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id), eat(item_id), give(item_id, target_id)."
+    "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id), eat(item_id), give(item_id, target_id), open(target_location), close(target_location)."
 )
 
 
@@ -61,13 +63,15 @@ def main():
     sim.register_tool(AnalyzeTool())
     sim.register_tool(EatTool())
     sim.register_tool(GiveTool())
+    sim.register_tool(OpenDoorTool())
+    sim.register_tool(CloseDoorTool())
 
     actor_id = "npc_sample"  # temporary player actor
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
-        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'eat <item>', 'give <item> <npc>', 'mem' to review memories, or 'quit'.")
+        print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'eat <item>', 'give <item> <npc>', 'open <loc>', 'close <loc>', 'mem' to review memories, or 'quit'.")
 
     while True:
         cmd = input("-> ").strip()
@@ -139,6 +143,12 @@ def main():
                 else:
                     print("Usage: give <item_id> <npc_id>")
                     continue
+            elif cmd.startswith("open "):
+                target = cmd.split(" ", 1)[1]
+                command = {"tool": "open", "params": {"target_location": target}}
+            elif cmd.startswith("close "):
+                target = cmd.split(" ", 1)[1]
+                command = {"tool": "close", "params": {"target_location": target}}
             elif cmd.startswith("equip "):
                 parts = cmd.split()
                 if len(parts) == 3:


### PR DESCRIPTION
## Summary
- add open and close tools to toggle passage states
- block movement through closed connections
- update CLI and data to demonstrate door mechanics

## Testing
- `python scripts/test_loader.py`
- `python scripts/cli_game.py <<'EOF'
move market_square
open market_square
move market_square
close town_square
move town_square
quit
EOF`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa282733c832eaff06c81018b3d0d