### PR TITLE
Add basic NPC thinking

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -43,10 +43,11 @@ This document tracks the implementation status of the engine against the design 
   - An `eat` tool allows consuming food items to reset hunger.
   - A `give` tool transfers items between actors occupying the same location.
   - `open` and `close` tools toggle passage status between locations, and `move` respects closed connections.
+  - A simple NPC think cycle lets non-player actors wander or comment when idle.
 
 ## Outstanding Tasks
 
 - Expand the toolset and improve combat handling (Phase 4).
-- Implement NPC AI with memory and conversation systems (Phase 5).
+- Develop NPC AI with memory and conversation systems (Phase 5).
 - Build polish features such as the narrator, fallback system and tag rules.
 

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -47,7 +47,8 @@ def main():
     world.load()
 
     narrator = Narrator(world)
-    sim = Simulator(world, narrator=narrator)
+    actor_id = "npc_sample"  # temporary player actor
+    sim = Simulator(world, narrator=narrator, player_id=actor_id)
     sim.register_tool(MoveTool())
     sim.register_tool(LookTool())
     sim.register_tool(GrabTool())
@@ -65,8 +66,6 @@ def main():
     sim.register_tool(GiveTool())
     sim.register_tool(OpenDoorTool())
     sim.register_tool(CloseDoorTool())
-
-    actor_id = "npc_sample"  # temporary player actor
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")


### PR DESCRIPTION
## Summary
- add npc_think method that gives non-player actors rudimentary actions
- allow Simulator.tick to trigger npc behavior
- document new NPC think cycle and wire player id into CLI

## Testing
- `python scripts/test_loader.py`
- `python - <<'PY'
from pathlib import Path
from engine.world_state import WorldState
from engine.simulator import Simulator
from engine.narrator import Narrator
from engine.tools.move import MoveTool
from engine.tools.talk import TalkTool
world = WorldState(Path('data'))
world.load()
world.locations_state['town_square'].connections_state.setdefault('market_square', {})['status'] = 'open'
world.locations_state['market_square'].connections_state.setdefault('town_square', {})['status'] = 'open'
sim = Simulator(world, narrator=Narrator(world), player_id='npc_sample')
sim.register_tool(MoveTool())
sim.register_tool(TalkTool())
for _ in range(6):
    sim.tick()
    print(sim.game_tick, {loc_id: loc.occupants for loc_id, loc in world.locations_state.items()})
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891519263fc832e952a5f2f9ad2e7b2