### PR TITLE
Implement basic NPC death handling

### DIFF
--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -147,4 +147,7 @@ class Narrator:
             actor = self.world.get_npc(event.actor_id)
             loc = self.world.get_location_static(event.target_ids[0])
             return f"{actor.name} closes the way to {loc.description}."
+        elif event.event_type == "npc_died":
+            actor = self.world.get_npc(event.actor_id)
+            return f"{actor.name} dies."
         return ""

--- a/engine/tools/attack.py
+++ b/engine/tools/attack.py
@@ -16,6 +16,9 @@ class AttackTool(Tool):
             return False
         attacker_loc = world.find_npc_location(actor.id)
         target_loc = world.find_npc_location(target_id)
+        target_npc = world.get_npc(target_id) if target_id in world.npcs else None
+        if target_npc and "dead" in target_npc.tags.get("dynamic", []):
+            return False
         return attacker_loc is not None and attacker_loc == target_loc
 
     def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:


### PR DESCRIPTION
## Summary
- Handle NPC death: drop inventory, mark actor as dead, and narrate the demise
- Simulator queues death events and skips turns for dead characters
- Attack tool ignores dead targets and LLM client imports json correctly

## Testing
- `python scripts/test_loader.py`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68924ea05bc4832ebbd6b7659a93a378