### PR TITLE
Add rest tool for healing over time

### DIFF
--- a/ROADMAP_PROGRESS.md
+++ b/ROADMAP_PROGRESS.md
@@ -45,6 +45,7 @@ This document tracks the implementation status of the engine against the design 
   - `open` and `close` tools toggle passage status between locations, and `move` respects closed connections.
   - A simple NPC think cycle lets non-player actors wander or comment when idle.
   - A `wait` tool lets actors deliberately pass time without acting.
+  - A `rest` tool lets actors recover hit points over time.
 
 ## Outstanding Tasks
 

--- a/engine/narrator.py
+++ b/engine/narrator.py
@@ -156,4 +156,11 @@ class Narrator:
             if ticks == 1:
                 return f"{actor.name} waits."
             return f"{actor.name} waits for {ticks} ticks."
+        elif event.event_type == "rest":
+            actor = self.world.get_npc(event.actor_id)
+            ticks = event.payload.get("ticks", 1)
+            healed = event.payload.get("healed", 0)
+            if ticks == 1:
+                return f"{actor.name} rests and recovers {healed} HP."
+            return f"{actor.name} rests for {ticks} ticks and recovers {healed} HP."
         return ""

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -233,6 +233,11 @@ class Simulator:
             msg = self.narrator.render(event)
             if msg:
                 print(msg)
+        elif event.event_type == "rest":
+            self.world.apply_event(event)
+            msg = self.narrator.render(event)
+            if msg:
+                print(msg)
         else:
             self.world.apply_event(event)
         # After applying and narrating, record perception for nearby actors

--- a/engine/tools/__init__.py
+++ b/engine/tools/__init__.py
@@ -15,6 +15,7 @@ from .eat import EatTool
 from .give import GiveTool
 from .toggle_starvation import ToggleStarvationTool
 from .wait import WaitTool
+from .rest import RestTool
 
 __all__ = [
     "MoveTool",
@@ -34,4 +35,5 @@ __all__ = [
     "GiveTool",
     "ToggleStarvationTool",
     "WaitTool",
+    "RestTool",
 ]

--- a/engine/tools/rest.py
+++ b/engine/tools/rest.py
@@ -1,0 +1,30 @@
+from typing import Dict, Any, List
+
+from .base import Tool
+from ..events import Event
+from ..world_state import WorldState
+from ..data_models import NPC
+
+
+class RestTool(Tool):
+    """Spend time to recover hit points."""
+
+    def __init__(self):
+        super().__init__(name="rest", time_cost=1)
+
+    def validate_intent(self, intent: Dict[str, Any], world: WorldState, actor: NPC) -> bool:
+        ticks = intent.get("ticks", 1)
+        return isinstance(ticks, int) and ticks >= 1
+
+    def generate_events(self, intent: Dict[str, Any], world: WorldState, actor: NPC, tick: int) -> List[Event]:
+        ticks = intent.get("ticks", 1)
+        healed = ticks  # heal 1 HP per tick
+        self.time_cost = ticks
+        return [
+            Event(
+                event_type="rest",
+                tick=tick + ticks,
+                actor_id=actor.id,
+                payload={"ticks": ticks, "healed": healed},
+            )
+        ]

--- a/engine/world_state.py
+++ b/engine/world_state.py
@@ -168,6 +168,13 @@ class WorldState:
             npc = self.npcs.get(target_id)
             if npc:
                 npc.hp = max(npc.hp - amount, 0)
+        elif event.event_type == "rest":
+            actor_id = event.actor_id
+            healed = event.payload.get("healed", 0)
+            npc = self.npcs.get(actor_id)
+            if npc:
+                max_hp = npc.attributes.get("constitution", npc.hp)
+                npc.hp = min(npc.hp + healed, max_hp)
         elif event.event_type == "equip":
             actor_id = event.actor_id
             item_id = event.target_ids[0]

--- a/scripts/cli_game.py
+++ b/scripts/cli_game.py
@@ -29,6 +29,7 @@ from engine.tools.open_door import OpenDoorTool
 from engine.tools.close_door import CloseDoorTool
 from engine.tools.toggle_starvation import ToggleStarvationTool
 from engine.tools.wait import WaitTool
+from engine.tools.rest import RestTool
 from engine.llm_client import LLMClient
 
 
@@ -37,7 +38,7 @@ SYSTEM_PROMPT = (
     "Return a JSON object describing the player's intended action. "
     "Available tools: look, move(target_location), grab(item_id), drop(item_id), attack(target_id), "
     "talk(content, target_id), talk_loud(content), scream(content), inventory(), stats(), equip(item_id, slot), unequip(slot), analyze(item_id), eat(item_id), give(item_id, target_id), open(target_location), close(target_location), toggle_starvation(enabled)."
-    " wait(ticks)."
+    " wait(ticks), rest(ticks)."
 )
 
 
@@ -71,12 +72,13 @@ def main():
     sim.register_tool(CloseDoorTool())
     sim.register_tool(ToggleStarvationTool())
     sim.register_tool(WaitTool())
+    sim.register_tool(RestTool())
     if args.llm:
         llm = LLMClient(Path("config/llm.json"))
         print("Type text commands. Say 'quit' to exit.")
     else:
         print("Type 'look', 'move <loc>', 'grab <item>', 'drop <item>', 'attack <npc>', 'talk <msg>' or 'talk <target> <msg>', 'shout <msg>', 'scream <msg>', 'inventory', 'stats', 'equip <item> <slot>', 'unequip <slot>', 'analyze <item>', 'eat <item>', 'give <item> <npc>', 'open <loc>', 'close <loc>', 'starvation <on/off>', 'mem' to review memories, or 'quit'.")
-        print("Use 'wait [ticks]' to pass time without acting.")
+        print("Use 'wait [ticks]' to pass time or 'rest [ticks]' to recover HP.")
 
     while True:
         cmd = input("-> ").strip()
@@ -187,6 +189,15 @@ def main():
                     print("Usage: wait [ticks]")
                     continue
                 command = {"tool": "wait", "params": {"ticks": ticks}}
+            elif cmd.startswith("rest"):
+                parts = cmd.split()
+                ticks = 1
+                if len(parts) == 2 and parts[1].isdigit():
+                    ticks = int(parts[1])
+                elif len(parts) > 2 or (len(parts) == 2 and not parts[1].isdigit()):
+                    print("Usage: rest [ticks]")
+                    continue
+                command = {"tool": "rest", "params": {"ticks": ticks}}
             elif cmd == "mem":
                 npc = world.get_npc(actor_id)
                 for mem in npc.short_term_memory:


### PR DESCRIPTION
## Summary
- Add a rest tool that lets actors recover hit points by spending ticks
- Support rest events in world state, simulator, narrator, and CLI
- Document rest feature in roadmap progress

## Testing
- `python -m py_compile engine/tools/rest.py engine/tools/__init__.py engine/world_state.py engine/narrator.py engine/simulator.py scripts/cli_game.py`
- `python - <<'PY'
from pathlib import Path
from engine.world_state import WorldState
from engine.simulator import Simulator
from engine.narrator import Narrator
from engine.tools.rest import RestTool

world = WorldState(Path('data'))
world.load()
actor_id = 'npc_sample'
world.npcs[actor_id].hp = 5
world.npcs['npc_enemy'].next_available_tick = 999
sim = Simulator(world, narrator=Narrator(world), player_id=actor_id)
sim.register_tool(RestTool())
sim.process_command(actor_id, {'tool': 'rest', 'params': {'ticks': 3}})
while sim.event_queue:
    sim.tick()
print('HP after rest:', world.get_npc(actor_id).hp)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689252ad7f8c832e8b429ea9839c76cb